### PR TITLE
fix(manifests): Updating manifests since now storage class is defined…

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -11,6 +11,12 @@ spec:
   image: image
   command: "python3 -u main.py --operator=tf --sleep=300 --tb-write=True"
 
+  storage:
+    sharedVolume:
+      mountPoint: "/mnt/shared"
+      sizeGB: 16
+      storageClass: longhorn-xfs
+
   tensorboard:
     enabled: true
 

--- a/manifests/manifest.jax.sample.yaml
+++ b/manifests/manifest.jax.sample.yaml
@@ -11,6 +11,12 @@ spec:
   image: image
   command: "python3 -u main.py --operator=jax --sleep=300 --tb-write=True"
 
+  storage:
+    sharedVolume:
+      mountPoint: "/mnt/shared"
+      sizeGB: 16
+      storageClass: longhorn-xfs
+
   tensorboard:
     enabled: true
 
@@ -26,4 +32,3 @@ spec:
             count: 0
             type: gpu
             product: nvidia-tesla-t4
-

--- a/manifests/manifest.kuberay.sample.yaml
+++ b/manifests/manifest.kuberay.sample.yaml
@@ -11,6 +11,12 @@ spec:
   image: image
   command: "python3 -u main.py --operator=kuberay --sleep=300 --tb-write=True"
 
+  storage:
+    sharedVolume:
+      mountPoint: "/mnt/shared"
+      sizeGB: 16
+      storageClass: longhorn-xfs
+
   debug:
     jupyter: false
 
@@ -30,4 +36,3 @@ spec:
           cpus: 1
           ramRatio: 2
           shmSizeGB: 0
-

--- a/manifests/manifest.pytorch.sample.yaml
+++ b/manifests/manifest.pytorch.sample.yaml
@@ -11,6 +11,12 @@ spec:
   image: image
   command: "python3 -u main.py --operator=pytorch --sleep=300 --tb-write=True"
 
+  storage:
+    sharedVolume:
+      mountPoint: "/mnt/shared"
+      sizeGB: 16
+      storageClass: longhorn-xfs
+
   tensorboard:
     enabled: true
 

--- a/manifests/manifest.tf.sample.yaml
+++ b/manifests/manifest.tf.sample.yaml
@@ -11,6 +11,12 @@ spec:
   image: image
   command: "python3 -u main.py --operator=tf --sleep=300 --tb-write=True"
 
+  storage:
+    sharedVolume:
+      mountPoint: "/mnt/shared"
+      sizeGB: 16
+      storageClass: longhorn-xfs
+
   tensorboard:
     enabled: true
 

--- a/manifests/manifest.xgboost.sample.yaml
+++ b/manifests/manifest.xgboost.sample.yaml
@@ -11,6 +11,12 @@ spec:
   image: image
   command: "python3 -u main.py --operator=xgboost --sleep=300 --tb-write=True"
 
+  storage:
+    sharedVolume:
+      mountPoint: "/mnt/shared"
+      sizeGB: 16
+      storageClass: longhorn-xfs
+
   tensorboard:
     enabled: true
 


### PR DESCRIPTION
This PR comes after the changes done in AIChor where the storage class is no longer defined during import but rather at experiment level, in the manifest

See: [MR](https://github.com/instadeepai/aichor-product/pull/993)